### PR TITLE
Center background image

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,7 @@ body {
   background-repeat: no-repeat;
   background-attachment: fixed;
   background-size: cover;
+  background-position: center;
 }
 
 .header {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48455312/85121740-a03b5b00-b225-11ea-9015-e3f379e9bef0.png)

Center the image instead of showing the left side of the image on mobile/smaller devices.